### PR TITLE
keyword bug fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ if __name__ == "__main__":
     print("start crawling...")
     random.shuffle(keywords)
     counter = 0
+    if len(keywords)==1:args.number_of_words=1
     for item in combinations(keywords, args.number_of_words):
         if counter == 4:
             break


### PR DESCRIPTION
In case the user wants to find images with one keyword the combination goes in a Error message which is "FileNotFindError: The system cannot find the path file specified: 'photos' " because the default sets to 2.
I'm just making changes to check if there is only one keyword don't make that Error message happen.